### PR TITLE
Fix the problem with ambiguity of logical/boolean

### DIFF
--- a/simulink/buses/struct2slbus.m
+++ b/simulink/buses/struct2slbus.m
@@ -130,6 +130,9 @@ function struct2slbus( s, BusName, varargin )
             elems(i).Name = sfields{i};
             elems(i).Dimensions = size(s.(sfields{i}));
             elems(i).DataType = class(s.(sfields{i}));
+            if strcmp(elems(i).DataType, 'logical')
+                elems(i).DataType = 'boolean';
+            end
             elems(i).SampleTime = -1;
             elems(i).Complexity = 'real';
             elems(i).SamplingMode = 'Sample based';


### PR DESCRIPTION
Fix the problem when a logical is used in the struct, as this is called boolean under simulink and lead to a non-meaningful error message.