### PR TITLE
Improve open_model()

### DIFF
--- a/test_framework/open_model.m
+++ b/test_framework/open_model.m
@@ -1,10 +1,15 @@
 function open_model(modelname)
 % open_model open or load a Simulink model for LADAC unit tests
-%   c = open_model( modelname ) opens the model 'modelname'. If the
-%   function finds the variable 'TEST_LADAC' in the base workspace it
-%   executes load_system(modelname) instead of open(modelname), that
-%   prevents Simulink from opening the model in a window, which saves time
-%   when the model is just opened for testing purposes.
+%   c = open_model( modelname ) opens the model 'modelname'.
+%   If the function finds the variable 'TEST_LADAC' in the base workspace,
+%   it doesn't open the model and only assigns the 'modelname' to the the
+%   variable 'MODEL_NAME' in the base workspace. 
+%   That prevents Simulink from opening the model in a window, which saves
+%   time when the model should be used for testing purposes.
+%   
+%   In addition, the model is only opened if it is not already open. This
+%   prevents the model from jumping to the model root and to the foreground
+%   when the init script is executed again.
 % 
 % Syntax:
 %   c = open_model(modelname)
@@ -16,15 +21,22 @@ function open_model(modelname)
 %   clc_clear, existInBaseWorkspace, validateModelBuild
 % 
 
-% Disclamer:
+% Disclaimer:
 %   SPDX-License-Identifier: GPL-3.0-only
 % 
 %   Copyright (C) 2020-2022 Fabian Guecker
-%   Copyright (C) 2022 TU Braunschweig, Institute of Flight Guidance
+%   Copyright (C) 2024 Jonas Withelm
+%   Copyright (C) 2024 TU Braunschweig, Institute of Flight Guidance
 % *************************************************************************
 
 if(~existInBaseWorkspace('TEST_LADAC'))
-    open(modelname);
+    if bdIsLoaded(modelname)
+        if ~strcmp(get_param(modelname,'Shown'), 'on')
+            open(modelname)
+        end
+    else
+        open(modelname)
+    end
 else
     assignin('base', 'MODEL_NAME', modelname);
 end


### PR DESCRIPTION
The documentation in the function was slightly incorrect and has been corrected.

In addition, the function has been extended to ensure that a model is only opened if it is not already open. This prevents the model from jumping to the model root and to the foreground when an init script is executed again.